### PR TITLE
Email settings for development

### DIFF
--- a/evalbase/evalbase/settings.py
+++ b/evalbase/evalbase/settings.py
@@ -134,7 +134,12 @@ STATICFILES_DIRS = [
 ]
 
 # Email setup
-EMAIL_HOST = 'smtp.nist.gov'
+# for deployment:
+# EMAIL_HOST = 'smtp.nist.gov'
+#
+# for development:
+EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
+EMAIL_FILE_PATH = Path(BASE_DIR) / 'sent_emails'
 
 # Login redirect
 LOGIN_REDIRECT_URL = 'home'


### PR DESCRIPTION
Changed the setup in settings.py to dump emails to a file.  For deployment, you can activate the EMAIL_HOST setting.